### PR TITLE
Add babel to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   "license": "MIT",
   "dependencies": {
     "async": "^1.5.2",
+    "babel": "^6.5.2",
     "babel-cli": "^6.4.0",
     "babel-preset-es2015": "^6.3.13",
     "babel-preset-stage-2": "^6.3.13",


### PR DESCRIPTION
Need babel in package.json in case it isn't installed globally.
